### PR TITLE
Pin setup-gcloud instead of using master

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -57,7 +57,7 @@ jobs:
 
     # Setup gcloud CLI
     - name: Setup gcloud CLI
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
         service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}


### PR DESCRIPTION
On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

References:

* https://github.com/google-github-actions/setup-gcloud/issues/539
* https://github.com/google-github-actions/setup-gcloud#versioning
* https://github.com/google-github-actions/setup-gcloud#-notices